### PR TITLE
Add ppeval

### DIFF
--- a/test/darray.jl
+++ b/test/darray.jl
@@ -529,3 +529,16 @@ facts("test axpy!") do
     @fact norm(convert(Array, LinAlg.axpy!(2.0, x, copy(y))) - LinAlg.axpy!(2.0, convert(Array, x), convert(Array, y))) < sqrt(eps()) => true
     @fact_throws LinAlg.axpy!(2.0, x, zeros(length(x) + 1)) => DimensionMismatch
 end
+
+facts("test ppeval") do
+    A = drandn((10, 10, nworkers()), workers(), [1, 1, nworkers()])
+    B = drandn((10, nworkers()), workers(), [1, nworkers()])
+
+    R = zeros(10, nworkers())
+    for i = 1:nworkers()
+        R[:, i] = convert(Array, A)[:, :, i]*convert(Array, B)[:, i]
+    end
+    @fact convert(Array, ppeval(*, A, B)) => roughly(R)
+    @fact sum(ppeval(eigvals, A)) => roughly(sum(ppeval(eigvals, A, eye(10, 10))))
+end
+


### PR DESCRIPTION
This function is not unlike `mapslices` but it allows for an arbitrary number of input arguments and it allows for broadcasting of elements.

I've found it a bit complicated to describe how the function works and therefore added some examples to the documentation. Please comment or modify the doc string for the function as you find appropriate.

It is very likely that the function hasn't found its final form. We might want to simplify the interface by assuming that only the last dimension is distributed and then implicitly redistribute if necessary.

cc: @ViralBShah, @alanedelman