### PR TITLE
Remove use of RemoteRefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,24 @@ false
 ```
 
 The ultimate ordering of operations will be dependent on how the Array is distributed.
+
+Garbage Collection and DArrays
+------------------------------
+
+When a DArray is constructed (typically on the master process), the returned DArray objects stores information on how the
+array is distributed, which procesor holds which indexes and so on. When the DArray object
+on the master process is garbage collected, all particpating workers are notified and
+localparts of the DArray freed on each worker.
+
+Since the size of the DArray object itself is small, a problem arises as `gc` on the master faces no memory pressure to
+collect the DArray immediately. This results in a delay of the memory being released on the participating workers.
+
+Therefore it is highly recommended to explcitly call `close(d::DArray)` as soon as user code
+has finished working with the distributed array.
+
+It is also important to note that the localparts of the DArray is collected from all particpating workers
+when the DArray object on the process creating the DArray is collected. It is therefore important to maintain
+a reference to a DArray object on the creating process for as long as it is being computed upon.
+
+`darray_closeall()` is another useful function to manage distributed memory. It releases all darrays created from
+the calling process, including any temporaries created during computation.


### PR DESCRIPTION
The use of RemoteRefs and the existing distributed gc implementation results in poor scaling when talking about 100s or 1000s of workers. For example, serializing a DArray distributed across 1000 workers will result in almost a million DGC messages.

This PR eschews the use of RemoteRefs in favour of a module level dictionary to associate "localparts" of the array. The changes are:

- every DArray has a unique `identity` comprising of the tuple (pid_where_created, one_up_number).
- module level dictionary called `registry` which has two mappings for every darray
  - (identity, :LOCALPART) -> localpart of the array
  - (identity, :DARRAY) -> the darrays metadata - pids, cuts, indexes, etc.
- Only the `identity` tuple is sent across the network while serializing/deserializing.
- Distributed memory can be explicitly released by calling `close(::DArray)` on the constructing process. This aids in the distributed memory being released immediately instead of waiting for the darray object to be collected on the constructing process (which today is unpredictable due to a lack of memory pressure)
- Not calling `close` results in the DArray being released when the object is collected as before. `close` is optional.

#### Limitations from existing implementation

- The DArray is released when the first reference to the darray is collected. The programmer thus has to ensure that the first handle to the DArray on the constructing process remains in scope for the duration of the computation. 
- Only the creating process and participating workers have full access to the DArray metadata. This is because the metadata is set upon construction and serialization of a DArray object only sends the identity tuple.

#### TODO
- [ ] - ~~Benchmark current implementation vs this PR on 1000 workers~~
- [x] - documentation updates
   
