### PR TITLE
add map_localpart!, use remotecall_wait instead of spawnat

### DIFF
--- a/src/DistributedArrays.jl
+++ b/src/DistributedArrays.jl
@@ -803,6 +803,12 @@ mappart(f::Callable, d::DArray) = DArray(i->f(localpart(d)), d)
 mappart(f::Callable, d1::DArray, d2::DArray) = DArray(d1) do I
     f(localpart(d1), localpart(d2))
 end
+function mappart!(f::Callable, d::DArray)
+    @sync for p in procs(d)
+        @spawnat p f(localpart(d))
+    end
+    return d
+end
 
 # Here we assume all the DArrays have
 # the same size and distribution


### PR DESCRIPTION
Apply `f` to the `localpart` instead of its elements. Useful for functions where `map!` is not appropriate.
~~Both `mappart` (existing already) and `mappart!` are not exported as of now.~~
Renamed `mappart` to `map_localparts`, added `map_localparts!`.

Also using `remotecall_wait` in `@sync` blocks instead of `@spawnat` where appropriate to avoid an unnecessary network call.