### PR TITLE
Fix distribute function

### DIFF
--- a/src/DistributedArrays.jl
+++ b/src/DistributedArrays.jl
@@ -11,6 +11,7 @@ end
 
 if VERSION < v"0.5.0-"
     typealias Future RemoteRef
+    typealias RemoteChannel RemoteRef
 end
 
 importall Base
@@ -491,7 +492,7 @@ function distribute(A::AbstractArray;
     dist = defaultdist(size(A), procs))
 
     owner = myid()
-    rr = Future()
+    rr = RemoteChannel()
     put!(rr, A)
     d = DArray(size(A), procs, dist) do I
         remotecall_fetch(() -> fetch(rr)[I...], owner)


### PR DESCRIPTION
This bug was causing the entire array to be distributed to be serialized to and from the workers in the init function.