### PR TITLE
Added sort on DVectors

### DIFF
--- a/src/DistributedArrays.jl
+++ b/src/DistributedArrays.jl
@@ -1280,53 +1280,80 @@ end
 
 # Sorting a DVector using samplesort
 
-function sample_n_setup_ref(d::DVector, sample_size)
+function sample_n_setup_ref(d::DVector, sample_size; kwargs...)
     lp = localpart(d)
     llp = length(lp)
+    np = length(procs(d))
     sample_size = llp > sample_size ? sample_size : llp
-    sample = lp[rand(1:llp, sample_size)]
-    ref = RemoteChannel(()->Channel(length(procs(d))))             # To collect parts to be sorted locally later.
+    sorted = sort(lp; kwargs...)
+    sample = sorted[collect(1:div(llp,sample_size):llp)]
+    ref = RemoteChannel(()->Channel(np+1))             # To collect parts to be sorted locally later.
+                                                       # First element is the locally sorted vector
+    put!(ref, sorted)
     return (sample, ref)
 end
 
 
-function scatter_n_sort_localparts{T}(d::DVector{T}, refs::Array{RemoteChannel}, boundaries::Array{T})
-    # send respective parts to correct workers
-    lp=localpart(d)
-    for (i,p) in enumerate(procs(d))
-        part_on_worker_i=lp[find(x-> (x >= boundaries[i]) && (x < boundaries[i+1]), lp)]
-        @async put!(refs[i], part_on_worker_i)
+function scatter_n_sort_localparts{T}(d, myidx, refs::Array{RemoteChannel}, boundaries::Array{T}; kwargs...)
+    if d==nothing
+        sorted = take!(refs[myidx])  # First entry in the remote channel is sorted localpart
+    else
+        sorted = sort(localpart(d); kwargs...)
     end
 
-    myidx = findfirst(procs(d), myid())
+    # send respective parts to correct workers, iterate over sorted array
+    p_sorted = 1
+    for (i,r) in enumerate(refs)
+        p_till = length(sorted)+1
+
+        # calculate range to send to refs[i]
+        ctr=1
+        for x in sorted[p_sorted:end]
+            if x > boundaries[i+1]
+                p_till = p_sorted+ctr-1
+                break
+            else
+                ctr += 1
+            end
+        end
+
+        if p_till == p_sorted
+            @async put!(r, Array(T,0))
+        else
+            v = sorted[p_sorted:p_till-1]
+            @async put!(r, v)
+        end
+
+        p_sorted = p_till
+    end
 
     # wait to receive all of my parts from all other workers
     lp_sorting=T[]
-    for _ in procs(d)
-        append!(lp_sorting, take!(refs[myidx]))
+    for _ in refs
+        v = take!(refs[myidx])
+        append!(lp_sorting, v)
     end
 
     sorted_ref=RemoteChannel()
-    put!(sorted_ref, sort!(lp_sorting))
+    put!(sorted_ref, sort!(lp_sorting; kwargs...))
 
     return sorted_ref
 end
 
-
-function samplesort{T}(d::DVector{T})
+function compute_boundaries{T}(d::DVector{T}; kwargs...)
     pids = procs(d)
-    nparts = length(pids)
+    np = length(pids)
     sample_sz_on_wrkr=512
 
     if VERSION < v"0.5.0-"
-        results=Array(Any,nparts)
+        results=Array(Any,np)
         @sync begin
             for (i,p) in enumerate(pids)
-                @async results[i] = remotecall_fetch(sample_n_setup_ref, p, d, sample_sz_on_wrkr)
+                @async results[i] = remotecall_fetch(sample_n_setup_ref, p, d, sample_sz_on_wrkr; kwargs...)
             end
         end
     else
-        results = asyncmap(p -> remotecall_fetch(sample_n_setup_ref, p, d, sample_sz_on_wrkr), pids)
+        results = asyncmap(p -> remotecall_fetch(sample_n_setup_ref, p, d, sample_sz_on_wrkr), pids; kwargs...)
     end
 
     samples = Array(T,0)
@@ -1338,18 +1365,95 @@ function samplesort{T}(d::DVector{T})
 
     refs=RemoteChannel[x[2] for x in results]
 
-    boundaries = samples[[1+(x-1)*div(length(samples), nparts) for x in 1:nparts]]
+    boundaries = samples[[1+(x-1)*div(length(samples), np) for x in 1:np]]
     push!(boundaries, typemax(T))
 
-    sorted_refs = Array(RemoteChannel, nparts)
+    return (boundaries, refs)
+end
+
+"""
+    sort(d::DVector; sample=true, kwargs...) -> DVector
+
+Sorts and returns a new distributed vector.
+
+The sorted vector may not have the same distribution as the original.
+
+Keyword argument `sample` can take values:
+
+- `true`: A sample of max size 512 is first taken from all nodes. This is used to balance
+the distribution of the sorted array on participating workers. Default is `true`.
+
+- `false`: No sampling is done. The sort assumes a uniform distribution between min(d) and max(d)
+
+- Tuple{Min, Max}: No sampling is done. The sort assumes a uniform distribution between min and max values
+
+- Array{T}: The passed array is assumed to be a sample of the distribution and is used to balance the sorted distribution.
+
+Other keyword arguments are passed through to `Base.sort` which is used to sort the local parts.
+See help for `Base.sort` for details.
+"""
+function Base.sort{T}(d::DVector{T}; sample=true, kwargs...)
+    pids = procs(d)
+    np = length(pids)
+
+    if sample==true
+        boundaries, refs = compute_boundaries(d)
+        presorted=true
+
+    elseif sample==false
+        # Assume an uniform distribution between min and max values
+        minmax=asyncmap(p->remotecall_fetch(d->(minimum(localpart(d)), maximum(localpart(d))), p, d), pids)
+        min_d = minimum(T[x[1] for x in minmax])
+        max_d = maximum(T[x[2] for x in minmax])
+
+        return sort(d; sample=(min_d,max_d), kwargs...)
+
+    elseif isa(sample, Tuple)
+        # Assume an uniform distribution between min and max values in the tuple
+        lb=sample[1]
+        ub=sample[2]
+
+        @assert lb<=ub
+
+        s = Array(T, np)
+        part = abs(ub - lb)/np
+        isnan(part) && throw(ArgumentError("lower and upper bounds must not be infinities"))
+
+        for n in 1:np
+            v = lb + (n-1)*part
+            if T <: Integer
+                s[n] = round(v)
+            else
+                s[n] = v
+            end
+        end
+        return sort(d; sample=s, kwargs...)
+
+    elseif isa(sample, Array)
+        # Provided array is used as a sample
+        samples = sort(copy(sample))
+        samples[1] = typemin(T)
+        boundaries = samples[[1+(x-1)*div(length(samples), np) for x in 1:np]]
+        push!(boundaries, typemax(T))
+        presorted=false
+
+        refs=RemoteChannel[RemoteChannel(p) for p in procs(d)]
+    else
+        throw(ArgumentError("keyword arg `sample` must be Boolean, Range or an actual sample of data"))
+    end
+
+    sorted_refs = Array(RemoteChannel, np)
     if VERSION < v"0.5.0-"
         @sync begin
             for (i,p) in enumerate(pids)
-                @async sorted_refs[i] = remotecall_fetch(scatter_n_sort_localparts, p, d, refs, boundaries)
+                @async sorted_refs[i] = remotecall_fetch(scatter_n_sort_localparts, p,
+                                            presorted?nothing:d, i, refs, boundaries; kwargs...)
             end
         end
     else
-        Base.asyncmap!(p -> remotecall_fetch(scatter_n_sort_localparts, p, d, refs, boundaries), sorted_refs, pids)
+        Base.asyncmap!((i,p) -> remotecall_fetch(scatter_n_sort_localparts, p,
+                                            presorted?nothing:d, i, refs, boundaries; kwargs...),
+                        sorted_refs, 1:np, pids)
     end
 
     # Construct a new DArray from the sorted refs

--- a/src/DistributedArrays.jl
+++ b/src/DistributedArrays.jl
@@ -1451,7 +1451,7 @@ function Base.sort{T}(d::DVector{T}; sample=true, kwargs...)
 
         refs=RemoteChannel[RemoteChannel(p) for p in procs(d)]
     else
-        throw(ArgumentError("keyword arg `sample` must be Boolean, Range or an actual sample of data"))
+        throw(ArgumentError("keyword arg `sample` must be Boolean, Tuple(Min,Max) or an actual sample of data : " * string(sample)))
     end
 
     local_sort_results = Array(Tuple, np)

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -763,7 +763,7 @@ facts("sort") do
     for i in 0:6
         for T in [Int, Float64]
             d=DistributedArrays.drand(T, 10^i)
-            for sample in [true, false, (minimum(d),maximum(d)), rand(T, 10^i>512 ? 512 : 10^i)]
+            for sample in Any[true, false, (minimum(d),maximum(d)), rand(T, 10^i>512 ? 512 : 10^i)]
                 d2=DistributedArrays.sort(d; sample=sample)
 
                 @fact length(d) --> length(d2)

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -759,7 +759,7 @@ facts("test matmatmul") do
     darray_closeall()  # close the temporaries created above
 end
 
-facts("samplesort") do
+facts("sort") do
     for i in 1:6
         for T in [Int, Float64]
             d=DistributedArrays.drand(T, 10^i)

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -759,6 +759,19 @@ facts("test matmatmul") do
     darray_closeall()  # close the temporaries created above
 end
 
+facts("samplesort") do
+    for i in 1:6
+        for T in [Int, Float64]
+            d=DistributedArrays.drand(T, 10^i)
+            d2=DistributedArrays.samplesort(d)
+
+            @fact length(d) --> length(d2)
+            @fact sort(convert(Array, d)) --> convert(Array, d2)
+        end
+    end
+    darray_closeall()  # close the temporaries created above
+end
+
 check_leaks()
 
 darray_closeall()

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -760,13 +760,15 @@ facts("test matmatmul") do
 end
 
 facts("sort") do
-    for i in 1:6
+    for i in 0:6
         for T in [Int, Float64]
             d=DistributedArrays.drand(T, 10^i)
-            d2=DistributedArrays.samplesort(d)
+            for sample in [true, false, (minimum(d),maximum(d)), rand(T, 10^i>512 ? 512 : 10^i)]
+                d2=DistributedArrays.sort(d; sample=sample)
 
-            @fact length(d) --> length(d2)
-            @fact sort(convert(Array, d)) --> convert(Array, d2)
+                @fact length(d) --> length(d2)
+                @fact sort(convert(Array, d)) --> convert(Array, d2)
+            end
         end
     end
     darray_closeall()  # close the temporaries created above


### PR DESCRIPTION
Added a samplesort. Currently only for distributed vectors.

On my local machine, it is slower than a serial sort (due to all-to-all communication) but not terribly off the charts.

For `10^8` random floats it takes `9.7` seconds for a serial sort vs `17.0` seconds for a distributed one.

cc: @andreasnoack  