### PR TITLE
Use testsets instead of FactCheck.

### DIFF
--- a/src/DistributedArrays.jl
+++ b/src/DistributedArrays.jl
@@ -902,6 +902,8 @@ for f in (:+, :-, :div, :mod, :rem, :&, :|, :$)
             B = samedist(A, B)
             map_localparts($f, A, B)
         end
+        ($f){T}(A::DArray{T}, B::Array{T}) = ($f)(A, distribute(B, A))
+        ($f){T}(A::Array{T}, B::DArray{T}) = ($f)(distribute(A, B), B)
     end
 end
 for f in (:.+, :.-, :.*, :./, :.%, :.<<, :.>>)
@@ -909,6 +911,8 @@ for f in (:.+, :.-, :.*, :./, :.%, :.<<, :.>>)
         function ($f){T}(A::DArray{T}, B::DArray{T})
             map_localparts($f, A, B)
         end
+        ($f){T}(A::DArray{T}, B::Array{T}) = ($f)(A, distribute(B, A))
+        ($f){T}(A::Array{T}, B::DArray{T}) = ($f)(distribute(A, B), B)
     end
 end
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
-FactCheck 0.2.3-
 StatsBase
+BaseTestNext

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,10 @@
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+
 # add at least 3 worker processes
 if nworkers() < 3
     n = max(3, min(8, Sys.CPU_CORES))
@@ -8,15 +15,12 @@ end
 
 using Compat
 import Compat.view
-# It should only be necessary to have FactCheck loaded on the master process, but
-# https://github.com/JuliaLang/julia/issues/15766. Move back to top when bug is fixed.
-using FactCheck
 using DistributedArrays
 using StatsBase # for fit(Histogram, ...)
 @everywhere using StatsBase # because exported functions are not exported on workers with using
 
 @everywhere srand(1234 + myid())
 
-include("darray.jl")
-
-FactCheck.exitstatus()
+@testset "DArray tests" begin
+    include("darray.jl")
+end


### PR DESCRIPTION
Define arithmetic between DArray and Array. It used to either fail or fall back
to the very inefficient AbstractArray implementation.

Enable test that had been disabled because of a bug in Base. The bug is fixed now.