### PR TITLE
Prevent timeout on travis

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,4 @@ using StatsBase # for fit(Histogram, ...)
 
 @everywhere srand(1234 + myid())
 
-@testset "DArray tests" begin
-    include("darray.jl")
-end
+include("darray.jl")


### PR DESCRIPTION
When we wrap everything in one `testset` we don't get any output for ~10minutes hitting the Travis timeout. 