### PR TITLE
Fix map_localparts and export it

### DIFF
--- a/src/DistributedArrays.jl
+++ b/src/DistributedArrays.jl
@@ -11,7 +11,7 @@ using Primes: factor
 
 # DArray exports
 export DArray, SubDArray, SubOrDArray, @DArray
-export dzeros, dones, dfill, drand, drandn, distribute, localpart, localindexes, ppeval
+export dzeros, dones, dfill, drand, drandn, distribute, localpart, map_localparts, localindexes, ppeval
 
 # non-array distributed data
 export ddata, gather

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -181,27 +181,46 @@ end
 (-)(D::DArray) = map(-, D)
 
 
-map_localparts(f::Callable, d::DArray) = DArray(i->f(localpart(d)), d)
-map_localparts(f::Callable, d1::DArray, d2::DArray) = DArray(d1) do I
-    f(localpart(d1), localpart(d2))
+function map_localparts(f::Callable, d::DArray)
+    r = Base.asyncmap!(similar(procs(d), Future), procs(d)) do p
+        remotecall_wait(p) do
+            f(localpart(d))
+        end
+    end
+    return DArray(r)
+end
+
+function map_localparts(f::Callable, d1::DArray, d2::DArray)
+    r = Base.asyncmap!(similar(procs(d1), Future), procs(d1)) do p
+        remotecall_wait(p) do
+            f(localpart(d1), localpart(d2))
+        end
+    end
+    return DArray(r)
 end
 
 function map_localparts(f::Callable, DA::DArray, A::Array)
     s = verified_destination_serializer(procs(DA), size(DA.indexes)) do pididx
         A[DA.indexes[pididx]...]
     end
-    DArray(DA) do I
-        f(localpart(DA), localpart(s))
+    r = Base.asyncmap!(similar(procs(DA), Future), procs(DA)) do p
+        remotecall_wait(p) do
+            f(localpart(DA), localpart(s))
+        end
     end
+    return DArray(r)
 end
 
 function map_localparts(f::Callable, A::Array, DA::DArray)
     s = verified_destination_serializer(procs(DA), size(DA.indexes)) do pididx
         A[DA.indexes[pididx]...]
     end
-    DArray(DA) do I
-        f(localpart(s), localpart(DA))
+    r = Base.asyncmap!(similar(procs(DA), Future), procs(DA)) do p
+        remotecall_wait(p) do
+            f(localpart(s), localpart(DA))
+        end
     end
+    return DArray(r)
 end
 
 function map_localparts!(f::Callable, d::DArray)
@@ -211,9 +230,14 @@ function map_localparts!(f::Callable, d::DArray)
     return d
 end
 
-# Here we assume all the DArrays have
-# the same size and distribution
-map_localparts(f::Callable, As::DArray...) = DArray(I->f(map(localpart, As)...), As[1])
+function map_localparts(f::Callable, As::DArray...)
+    r = Base.asyncmap!(similar(procs(As[1]), Future), procs(As[1])) do p
+        remotecall_wait(p) do
+            f(map(localpart, As)...)
+        end
+    end
+    return DArray(r)
+end
 
 
 function samedist(A::DArray, B::DArray)

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -182,7 +182,8 @@ end
 
 
 function map_localparts(f::Callable, d::DArray)
-    r = Base.asyncmap!(similar(procs(d), Future), procs(d)) do p
+    r = similar(procs(d), Future)
+    Base.asyncmap!(r, procs(d)) do p
         remotecall_wait(p) do
             f(localpart(d))
         end
@@ -191,7 +192,8 @@ function map_localparts(f::Callable, d::DArray)
 end
 
 function map_localparts(f::Callable, d1::DArray, d2::DArray)
-    r = Base.asyncmap!(similar(procs(d1), Future), procs(d1)) do p
+    r = similar(procs(d1), Future)
+    Base.asyncmap!(r, procs(d1)) do p
         remotecall_wait(p) do
             f(localpart(d1), localpart(d2))
         end
@@ -203,7 +205,8 @@ function map_localparts(f::Callable, DA::DArray, A::Array)
     s = verified_destination_serializer(procs(DA), size(DA.indexes)) do pididx
         A[DA.indexes[pididx]...]
     end
-    r = Base.asyncmap!(similar(procs(DA), Future), procs(DA)) do p
+    r = similar(procs(DA), Future)
+    Base.asyncmap!(r, procs(DA)) do p
         remotecall_wait(p) do
             f(localpart(DA), localpart(s))
         end
@@ -215,7 +218,8 @@ function map_localparts(f::Callable, A::Array, DA::DArray)
     s = verified_destination_serializer(procs(DA), size(DA.indexes)) do pididx
         A[DA.indexes[pididx]...]
     end
-    r = Base.asyncmap!(similar(procs(DA), Future), procs(DA)) do p
+    r = similar(procs(DA), Future)
+    Base.asyncmap!(r, procs(DA)) do p
         remotecall_wait(p) do
             f(localpart(s), localpart(DA))
         end
@@ -231,7 +235,8 @@ function map_localparts!(f::Callable, d::DArray)
 end
 
 function map_localparts(f::Callable, As::DArray...)
-    r = Base.asyncmap!(similar(procs(As[1]), Future), procs(As[1])) do p
+    r = similar(procs(As[1]), Future)
+    Base.asyncmap!(r, procs(As[1])) do p
         remotecall_wait(p) do
             f(map(localpart, As)...)
         end

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -924,6 +924,24 @@ check_leaks()
 
 d_closeall()
 
+@testset "test map_localpart" begin
+    a1 = randn(10, 10)
+    d1 = distribute(a1)
+    @test Array(map_localparts(abs, d1)) == map(abs, a1)
+    @test Array(map_localparts(+, d1, d1)) == map(+, a1, a1)
+    @test Array(map_localparts(+, d1, a1)) == map(+, a1, a1)
+    @test Array(map_localparts(+, a1, d1)) == map(+, a1, a1)
+    @test Array(map_localparts(+, d1, d1, d1)) == map(+, a1, a1, a1)
+
+    d2 = @DArray [i for i in 1:40]
+    y1 = map_localparts(sum, d2)
+    y2 = [0; cumsum(Array(y1))[1:end-1]]
+    y3 = map_localparts((t,s) -> cumsum(t) .+ s[1], d2, distribute(y2))
+    @test Array(y3) == cumsum(Array(d2))
+end
+
+darray_closeall()
+
 @testset "test for any leaks" begin
     sleep(1.0)     # allow time for any cleanup to complete
     allrefszero = Bool[remotecall_fetch(()->length(DistributedArrays.refs) == 0, p) for p in procs()]


### PR DESCRIPTION
`map_localparts` used to assume that the output has the same shape as the input. However, the function is useful in a broader setting so I've changed the function to query the return shape and I've also exported it. @amitmurthy do you see any obvious inefficiencies in this approach?
