### PR TITLE
Remove Base.Predicate

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -141,7 +141,6 @@ for (fn, fr) in ((:any, :|),
                  (:count, :+))
     @eval begin
         (Base.$fn)(f::typeof(identity), d::DArray) = mapreduce(f, $fr, d)
-        (Base.$fn)(f::Base.Predicate{1}, d::DArray) = mapreduce(f, $fr, d)
         (Base.$fn)(f::Callable, d::DArray) = mapreduce(f, $fr, d)
     end
 end


### PR DESCRIPTION
`Predicate` was removed from Base recently, so this line should cause an `UndefVarError` on nightly 0.6. However, this removal shouldn't affect anything on other versions of Julia, partly because the `Predicate{1}` syntax is not correct AFAIK; it creates a type that can't be `convert`ed to, so this method will never actually get called.