### PR TITLE
Define general broadcasting of DArrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - nightly
 matrix:
-  allow_failures:
-    - julia: nightly
+  # allow_failures:
+    # - julia: nightly
 notifications:
   email: false
 before_install:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5-
+julia 0.6-
 Primes

--- a/src/darray.jl
+++ b/src/darray.jl
@@ -61,7 +61,9 @@ empty_localpart(T,N,A) = convert(A, Array(T, ntuple(zero, N)))
 typealias SubDArray{T,N,D<:DArray} SubArray{T,N,D}
 typealias SubOrDArray{T,N} Union{DArray{T,N}, SubDArray{T,N}}
 
-localtype{T,N,S}(A::DArray{T,N,S}) = S
+localtype{T,N,S}(::Type{DArray{T,N,S}}) = S
+localtype{T,N,D}(::Type{SubDArray{T,N,D}}) = localtype(D)
+localtype(A::SubOrDArray) = localtype(typeof(A))
 localtype(A::AbstractArray) = typeof(A)
 
 ## core constructors ##

--- a/src/darray.jl
+++ b/src/darray.jl
@@ -274,7 +274,7 @@ end
 # get array of start indexes for dividing sz into nc chunks
 function defaultdist(sz::Int, nc::Int)
     if sz >= nc
-        return round(Int, linspace(1, sz+1, nc+1))
+        return round.(Int, linspace(1, sz+1, nc+1))
     else
         return [[1:(sz+1);], zeros(Int, nc-sz);]
     end

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -2,11 +2,11 @@
 
 Base.map(f, d::DArray) = DArray(I->map(f, localpart(d)), d)
 
-Base.map!{F}(f::F, d::DArray) = begin
-    @sync for p in procs(d)
-        @async remotecall_fetch((f,d)->(map!(f, localpart(d)); nothing), p, f, d)
+Base.map!{F}(f::F, dest::DArray, src::DArray) = begin
+    @sync for p in procs(dest)
+        @async remotecall_fetch(() -> (map!(f, localpart(dest), src[localindexes(dest)...]); nothing), p)
     end
-    return d
+    return dest
 end
 
 Base.Broadcast.containertype{D<:DArray}(::Type{D}) = DArray

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -171,7 +171,7 @@ t=@testset "test DArray reduce" begin
     end
 
     @testset "test map! / reduce" begin
-        map!(x->1, D)
+        map!(x->1, D, D)
         @test reduce(+, D) == 100
     end
     close(D)
@@ -343,16 +343,16 @@ end
 check_leaks(t)
 
 t=@testset "test max / min / sum" begin
-    a = map(x->Int(round(rand() * 100)) - 50, Array(Int, 100,1000))
+    a = map(x -> Int(round(rand() * 100)) - 50, Array(Int, 100,1000))
     d = distribute(a)
 
-    @test sum(d) == sum(a)
-    @test maximum(d) == maximum(a)
-    @test minimum(d) == minimum(a)
-    @test maxabs(d) == maxabs(a)
-    @test minabs(d) == minabs(a)
-    @test sumabs(d) == sumabs(a)
-    @test sumabs2(d) == sumabs2(a)
+    @test sum(d)          == sum(a)
+    @test maximum(d)      == maximum(a)
+    @test minimum(d)      == minimum(a)
+    @test maximum(abs, d) == maximum(abs, a)
+    @test minimum(abs, d) == minimum(abs, a)
+    @test sum(abs, d)     == sum(abs, a)
+    @test sum(abs2, d)    == sum(abs2, a)
     close(d)
 end
 
@@ -720,11 +720,11 @@ t=@testset "test scalar ops" begin
     c = drand(20,20)
     d = convert(Array, c)
 
-    @testset "$f" for f in (+, -, .+, .-, .*, ./, .%, div, mod)
+    @testset "$f" for f in (:+, :-, :.+, :.-, :.*, :./, :.%)
         x = rand()
-        @test f(a, x) == f(b, x)
-        @test f(x, a) == f(x, b)
-        @test f(a, c) == f(b, d)
+        @test @eval ($f)($a, $x) == ($f)($b, $x)
+        @test @eval ($f)($x, $a) == ($f)($x, $b)
+        @test @eval ($f)($a, $c) == ($f)($b, $d)
     end
 
     close(a)
@@ -732,10 +732,10 @@ t=@testset "test scalar ops" begin
 
     a = dones(Int, 20, 20)
     b = convert(Array, a)
-    @testset "$f" for f in (.<<, .>>)
-        @test f(a, 2) == f(b, 2)
-        @test f(2, a) == f(2, b)
-        @test f(a, a) == f(b, b)
+    @testset "$f" for f in (:.<<, :.>>)
+        @test @eval ($f)($a, 2)  == ($f)($b, 2)
+        @test @eval ($f)(2, $a)  == ($f)(2, $b)
+        @test @eval ($f)($a, $a) == ($f)($b, $b)
     end
 
     @testset "$f" for f in (rem,)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,8 +20,6 @@ const OTHERIDS = filter(id-> id != MYID, procs())[rand(1:(nprocs()-1))]
 
 # On 0.6, @testset does not display the test description automatically anymore.
 function print_test_desc(t, n=0)
-    VERSION < v"0.6-" && return
-
     println(repeat(" ", n), "Passed : ", t.description)
     for t2 in t.results
         if isa(t2, Base.Test.DefaultTestSet)


### PR DESCRIPTION
Right now, the broadcasting functionality is frustratingly slow but I think it works correctly which is a start. Hopefully, we'll be able to speed things up later. Although this code is pretty type unstable, I don't think the performance issues are in this PR but rather in base or `DistributedArrays` in general. See also #119.

I've dropped support for Julia 0.5. The broadcasting code in base doesn't have a stable API for new `AbstractArrays` extensions so it would require a separate implementation to support 0.5 which is not worth it with 0.6 being released relative soon.