### PR TITLE
Make drand work more generally

### DIFF
--- a/src/darray.jl
+++ b/src/darray.jl
@@ -401,8 +401,8 @@ dfill(v, d1::Integer, drest::Integer...) = dfill(v, convert(Dims, tuple(d1, dres
 Construct a distributed uniform random array.
 Trailing arguments are the same as those accepted by `DArray`.
 """
-drand{T}(::Type{T}, dims::Dims, args...) = DArray(I->rand(T,map(length,I)), dims, args...)
-drand{T}(::Type{T}, d1::Integer, drest::Integer...) = drand(T, convert(Dims, tuple(d1, drest...)))
+drand(r, dims::Dims, args...) = DArray(I -> rand(r, map(length,I)), dims, args...)
+drand(r, d1::Integer, drest::Integer...) = drand(r, convert(Dims, tuple(d1, drest...)))
 drand(d1::Integer, drest::Integer...) = drand(Float64, convert(Dims, tuple(d1, drest...)))
 drand(d::Dims, args...)  = drand(Float64, d, args...)
 

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -543,6 +543,20 @@ t=@testset "test drand" begin
         close(A)
     end
 
+    @testset "1D drand, UnitRange" begin
+        A = drand(1:10, 100)
+        @test eltype(A) == Int
+        @test size(A) == (100,)
+        close(A)
+    end
+
+    @testset "1D drand, Array" begin
+        A = drand([-1,0,1], 100)
+        @test eltype(A) == Int
+        @test size(A) == (100,)
+        close(A)
+    end
+
     @testset "2D drand, Dims constructor" begin
         A = drand((50,50))
         @test eltype(A) == Float64


### PR DESCRIPTION
This makes `rand` work for e.g. `AbstractArray`s such that `drand(1:10, 4)` works.