### PR TITLE
Define a hash function for DArray

### DIFF
--- a/src/darray.jl
+++ b/src/darray.jl
@@ -66,6 +66,8 @@ localtype{T,N,D}(::Type{SubDArray{T,N,D}}) = localtype(D)
 localtype(A::SubOrDArray) = localtype(typeof(A))
 localtype(A::AbstractArray) = typeof(A)
 
+Base.hash(d::DArray, h::UInt) = Base.hash(d.id, h)
+
 ## core constructors ##
 
 function DArray(id, init, dims, pids, idxs, cuts)

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -1,6 +1,6 @@
 using SpecialFunctions
 
-@testset "test distribute" begin
+@testset "test distribute and other constructors" begin
     A = rand(1:100, (100,100))
 
     @testset "test default distribute" begin
@@ -39,6 +39,11 @@ using SpecialFunctions
 
         close(DA1)
         close(DA2)
+    end
+
+    @testset "Global DArray serialization issue #134" begin
+        global A134 = drandn(1)
+        @test DArray(I -> DistributedArrays.localpart(A134), A134) == A134
     end
 end
 


### PR DESCRIPTION
Global objects captured in a closure are serialized only if their hash value is changed. The absence of DistributedArrays.hash resulted in the default hash function trying to fetch remote elements during serialization of the darray object which resulted in a hang.

DistributedArrays.hash is now implemented and is a hash of the cluster wide unique id that each darray object has.  

Closes #134 