### PR TITLE
Update for julia-0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
 matrix:
   # allow_failures:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Distributed Arrays will only work on Julia v0.4.0 or later.
 `DArray`s have been removed from Julia Base library in v0.4 so it is now necessary to import the `DistributedArrays` package on all spawned processes.
 
 ```julia
-@everywhere using DistributedArrays
+using DistributedArrays
 ```
 
 Distributed Arrays
@@ -76,12 +76,12 @@ Indexing via symbols is used for this, specifically symbols `:L`,`:LP`,`:l`,`:lp
 are all equivalent. For example, `d[:L]` returns the localpart of `d`
 while `d[:L]=v` sets `v` as the localpart of `d`.
 
-* `localindexes(a::DArray)` gives a tuple of the index ranges owned by the
+* `localindices(a::DArray)` gives a tuple of the index ranges owned by the
 local process.
 
 * `convert(Array, a::DArray)` brings all the data to the local process.
 
-Indexing a `DArray` (square brackets) with ranges of indexes always
+Indexing a `DArray` (square brackets) with ranges of indices always
 creates a `SubArray`, not copying any data.
 
 
@@ -205,7 +205,7 @@ seen in this simple example:
 ```julia
 julia> addprocs(8);
 
-julia> @everywhere using DistributedArrays
+julia> using DistributedArrays
 
 julia> A = fill(1.1, (100,100));
 
@@ -227,7 +227,7 @@ Garbage Collection and DArrays
 ------------------------------
 
 When a DArray is constructed (typically on the master process), the returned DArray objects stores information on how the
-array is distributed, which procesor holds which indexes and so on. When the DArray object
+array is distributed, which procesor holds which indices and so on. When the DArray object
 on the master process is garbage collected, all particpating workers are notified and
 localparts of the DArray freed on each worker.
 
@@ -317,10 +317,10 @@ Example
 This toy example exchanges data with each of its neighbors `n` times.
 
 ```
-using DistributedArrays
+using Distributed
 addprocs(8)
-@everywhere importall DistributedArrays
-@everywhere importall DistributedArrays.SPMD
+using DistributedArrays
+using DistributedArrays.SPMD
 
 d_in=d=DArray(I->fill(myid(), (map(length,I)...)), (nworkers(), 2), workers(), [nworkers(),1])
 d_out=ddata()

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ addprocs(8)
 @everywhere using DistributedArrays.SPMD
 
 d_in=d=DArray(I->fill(myid(), (map(length,I)...,)), (nworkers(), 2), workers(), [nworkers(),1])
-d_out=ddata(); # TODO cannot show
+d_out=ddata();
 
 # define the function everywhere
 @everywhere function foo_spmd(d_in, d_out, n)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
+julia 0.7-beta
 Primes

--- a/src/DistributedArrays.jl
+++ b/src/DistributedArrays.jl
@@ -8,7 +8,7 @@ using LinearAlgebra
 
 import Base: +, -, *, div, mod, rem, &, |, xor
 import Base.Callable
-import LinearAlgebra: axpy!, dot, norm,
+import LinearAlgebra: axpy!, dot, norm
 
 import Primes
 import Primes: factor

--- a/src/DistributedArrays.jl
+++ b/src/DistributedArrays.jl
@@ -8,7 +8,7 @@ using LinearAlgebra
 
 import Base: +, -, *, div, mod, rem, &, |, xor
 import Base.Callable
-import LinearAlgebra.BLAS: axpy!
+import LinearAlgebra: axpy!, dot, norm,
 
 import Primes
 import Primes: factor

--- a/src/DistributedArrays.jl
+++ b/src/DistributedArrays.jl
@@ -2,16 +2,20 @@ __precompile__()
 
 module DistributedArrays
 
-importall Base
-import Base.Callable
-import Base.BLAS: axpy!
+using Distributed
+using Serialization
+using LinearAlgebra
 
-using Primes
-using Primes: factor
+import Base: +, -, *, div, mod, rem, &, |, xor
+import Base.Callable
+import LinearAlgebra.BLAS: axpy!
+
+import Primes
+import Primes: factor
 
 # DArray exports
 export DArray, SubDArray, SubOrDArray, @DArray
-export dzeros, dones, dfill, drand, drandn, distribute, localpart, localindexes, ppeval
+export dzeros, dones, dfill, drand, drandn, distribute, localpart, localindices, ppeval
 
 # non-array distributed data
 export ddata, gather

--- a/src/core.jl
+++ b/src/core.jl
@@ -17,7 +17,7 @@ release_localpart(id::Tuple) = (delete!(registry, id); nothing)
 release_localpart(d) = release_localpart(d.id)
 
 function close_by_id(id, pids)
-#   @schedule println("Finalizer for : ", id)
+#   @async println("Finalizer for : ", id)
     global refs
     @sync begin
         for p in pids
@@ -31,10 +31,10 @@ function close_by_id(id, pids)
     nothing
 end
 
-function close(d::DArray)
-#    @schedule println("close : ", d.id, ", object_id : ", object_id(d), ", myid : ", myid() )
+function Base.close(d::DArray)
+#    @async println("close : ", d.id, ", object_id : ", object_id(d), ", myid : ", myid() )
     if (myid() == d.id[1]) && d.release
-        @schedule close_by_id(d.id, d.pids)
+        @async close_by_id(d.id, d.pids)
         d.release = false
     end
     nothing
@@ -55,7 +55,7 @@ end
 
 Get the vector of processes storing pieces of DArray `d`.
 """
-Base.procs(d::DArray) = d.pids
+Distributed.procs(d::DArray) = d.pids
 
 """
     localpart(A)

--- a/src/core.jl
+++ b/src/core.jl
@@ -55,7 +55,8 @@ end
 
 Get the vector of processes storing pieces of DArray `d`.
 """
-Distributed.procs(d::DArray) = d.pids
+Distributed.procs(d::DArray)    = d.pids
+Distributed.procs(d::SubDArray) = procs(parent(d))
 
 """
     localpart(A)

--- a/src/darray.jl
+++ b/src/darray.jl
@@ -377,13 +377,33 @@ function Base.:(==)(d::DArray{<:Any,<:Any,A}, a::AbstractArray) where A
         return all(b)
     end
 end
-Base.:(==)(d::SubDArray, a::AbstractArray) = copy(d) == a
+function Base.:(==)(d::SubDArray, a::AbstractArray)
+    cd = copy(d)
+    t = cd == a
+    close(cd)
+    return t
+end
 Base.:(==)(a::AbstractArray, d::DArray) = d == a
 Base.:(==)(a::AbstractArray, d::SubDArray) = d == a
 Base.:(==)(d1::DArray, d2::DArray) = invoke(==, Tuple{DArray, AbstractArray}, d1, d2)
-Base.:(==)(d1::SubDArray, d2::DArray) = copy(d1) == d2
-Base.:(==)(d1::DArray, d2::SubDArray) = d1 == copy(d2)
-Base.:(==)(d1::SubDArray, d2::SubDArray) = copy(d1) == copy(d2)
+function Base.:(==)(d1::SubDArray, d2::DArray)
+    cd1 = copy(d1)
+    t = cd1 == d2
+    close(cd1)
+    return t
+end
+function Base.:(==)(d1::DArray, d2::SubDArray)
+    cd2 = copy(d2)
+    t = d1 == cd2
+    close(cd2)
+    return t
+end
+function Base.:(==)(d1::SubDArray, d2::SubDArray)
+    cd1 = copy(d1)
+    t = cd1 == d2
+    close(cd1)
+    return t
+end
 
 """
     locate(d::DArray, I::Int...)

--- a/src/darray.jl
+++ b/src/darray.jl
@@ -198,7 +198,7 @@ function DArray(refs)
     nindices = Array{NTuple{length(dimdist),UnitRange{Int}}}(undef, dimdist...)
 
     for i in 1:length(nindices)
-        subidx = CartesianIndices(dimdist)[i] #ind2sub(dimdist, i)
+        subidx = CartesianIndices(dimdist)[i]
         nindices[i] = ntuple(length(subidx)) do x
             idx_in_dim = subidx[x]
             startidx = 1

--- a/src/darray.jl
+++ b/src/darray.jl
@@ -574,6 +574,16 @@ Base.copyto!(dest::SubOrDArray, src::SubOrDArray) = begin
 end
 Base.copy!(dest::SubOrDArray, src::SubOrDArray) = copyto!(dest, src)
 
+function Base.deepcopy(src::DArray)
+    dest = similar(src)
+    asyncmap(procs(src)) do p
+        remotecall_fetch(p) do
+            dest[:L] = deepcopy(src[:L])
+        end
+    end
+    return dest
+end
+
 # local copies are obtained by convert(Array, ) or assigning from
 # a SubDArray to a local Array.
 

--- a/src/darray.jl
+++ b/src/darray.jl
@@ -708,7 +708,7 @@ function Base.setindex!(a::Array, s::SubDArray,
                 # partial chunk
                 @async a[idxs...] =
                     remotecall_fetch(d.pids[i]) do
-                        view(localpart(d), [K[j]-first(K_c[j])+1 for j=1:length(J)]...)
+                        view(localpart(d), [K[j].-first(K_c[j]).+1 for j=1:length(J)]...)
                     end
             end
         end

--- a/src/darray.jl
+++ b/src/darray.jl
@@ -153,7 +153,7 @@ function ddata(;T::Type=Any, init::Function=I->nothing, pids=workers(), data::Ve
 end
 
 function gather(d::DArray{T,1,T}) where T
-    a=Array{T}(length(procs(d)))
+    a=Array{T}(undef, length(procs(d)))
     @sync for (i,p) in enumerate(procs(d))
         @async a[i] = remotecall_fetch(localpart, p, d)
     end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -221,7 +221,7 @@ function _matmatmul!(α::Number, A::DMatrix, B::AbstractMatrix, β::Number, C::D
                     if tA == 'T'
                         return transpose(localpart(A))*convert(localtype(B), Bjk)
                     elseif tA == 'C'
-                        return localpart(A)'*convert(localtype(B), Bjk)
+                        return ctranspose(localpart(A))*convert(localtype(B), Bjk)
                     else
                         return localpart(A)*convert(localtype(B), Bjk)
                     end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -2,7 +2,7 @@ function Base.copy(D::Adjoint{T,<:DArray{T,2}}) where T
     DArray(reverse(size(D)), procs(D)) do I
         lp = Array{T}(map(length, I))
         rp = convert(Array, D[reverse(I)...])
-        ctranspose!(lp, rp)
+        adjoint!(lp, rp)
     end
 end
 

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -73,17 +73,6 @@ function Base.reducedim_initarray(A::DArray, region, v0, ::Type{R}) where {R}
 end
 Base.reducedim_initarray(A::DArray, region, v0::T) where {T} = Base.reducedim_initarray(A, region, v0, T)
 
-# function Base.reducedim_initarray0(A::DArray, region, v0, ::Type{R}) where {R}
-#     # Store reduction on lowest pids
-#     pids = A.pids[ntuple(i -> i in region ? (1:1) : (:), ndims(A))...]
-#     chunks = similar(pids, Future)
-#     @sync for i in eachindex(pids)
-#         @async chunks[i...] = remotecall_wait(() -> Base.reducedim_initarray0(localpart(A), region, v0, R), pids[i...])
-#     end
-#     return DArray(chunks)
-# end
-# Base.reducedim_initarray0(A::DArray, region, v0::T) where {T} = Base.reducedim_initarray0(A, region, v0, T)
-
 # Compute mapreducedim of each localpart and store the result in a new DArray
 function mapreducedim_within(f, op, A::DArray, region)
     arraysize = [size(A)...]

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -127,10 +127,6 @@ function Base.mapreducedim!(f, op, R::DArray, A::DArray)
     return mapreducedim_between!(identity, op, R, B, region)
 end
 
-# function Base.mapreducedim(f, op, R::DArray, A::DArray)
-#     Base.mapreducedim!(f, op, Base.reducedim_initarray(A, region, v0), A)
-# end
-
 function nnz(A::DArray)
     B = asyncmap(A.pids) do p
         remotecall_fetch(nnz∘localpart, p, A)

--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -2,7 +2,7 @@ function Serialization.serialize(S::AbstractSerializer, d::DArray{T,N,A}) where 
     # Only send the ident for participating workers - we expect the DArray to exist in the
     # remote registry. DO NOT send the localpart.
     destpid = worker_id_from_socket(S.io)
-    serialize_type(S, typeof(d))
+    Serialization.serialize_type(S, typeof(d))
     if (destpid in d.pids) || (destpid == d.id[1])
         serialize(S, (true, d.id))    # (id_only, id)
     else
@@ -64,7 +64,7 @@ function Serialization.serialize(S::AbstractSerializer, s::DestinationSerializer
     pid = worker_id_from_socket(S.io)
     pididx = findfirst(isequal(pid), s.pids)
     @assert pididx !== nothing
-    serialize_type(S, typeof(s))
+    Serialization.serialize_type(S, typeof(s))
     serialize(S, s.generate(pididx))
 end
 

--- a/src/sort.jl
+++ b/src/sort.jl
@@ -66,7 +66,7 @@ function compute_boundaries(d::DVector{T}; kwargs...) where T
 
     results = asyncmap(p -> remotecall_fetch(sample_n_setup_ref, p, d, sample_sz_on_wrkr; kwargs...), pids)
 
-    samples = Array{T}(0)
+    samples = Array{T}(undef, 0)
     for x in results
         append!(samples, x[1])
     end

--- a/src/sort.jl
+++ b/src/sort.jl
@@ -38,7 +38,7 @@ function scatter_n_sort_localparts(d, myidx, refs, boundaries::Array{T}; by = id
         end
 
         if p_till == p_sorted
-            @async put!(r, Array{T}(0))
+            @async put!(r, Array{T}(undef,0))
         else
             v = sorted[p_sorted:p_till-1]
             @async put!(r, v)
@@ -66,7 +66,7 @@ function compute_boundaries(d::DVector{T}; kwargs...) where T
 
     results = asyncmap(p -> remotecall_fetch(sample_n_setup_ref, p, d, sample_sz_on_wrkr; kwargs...), pids)
 
-    samples = Array{T}(undef, 0)
+    samples = Array{T}(undef,0)
     for x in results
         append!(samples, x[1])
     end
@@ -128,7 +128,7 @@ function Base.sort(d::DVector{T}; sample=true, kwargs...) where T
 
         @assert lb<=ub
 
-        s = Array{T}(np)
+        s = Array{T}(undef,np)
         part = abs(ub - lb)/np
         (isnan(part) || isinf(part)) && throw(ArgumentError("lower and upper bounds must not be infinities"))
 
@@ -155,7 +155,7 @@ function Base.sort(d::DVector{T}; sample=true, kwargs...) where T
         throw(ArgumentError("keyword arg `sample` must be Boolean, Tuple(Min,Max) or an actual sample of data : " * string(sample)))
     end
 
-    local_sort_results = Array{Tuple}(np)
+    local_sort_results = Array{Tuple}(undef,np)
 
     Base.asyncmap!((i,p) -> remotecall_fetch(
             scatter_n_sort_localparts, p, presorted ? nothing : d, i, refs, boundaries; kwargs...),

--- a/src/spmd.jl
+++ b/src/spmd.jl
@@ -198,7 +198,7 @@ function scatter(x, pid::Int; tag=nothing, pids=procs())
             p == pid && continue
             send_msg(p, :scatter, x[cnt*(i-1)+1:cnt*i], tag)
         end
-        myidx = findfirst(sort(pids), pid)
+        myidx = findfirst(isequal(pid), sort(pids))
         return x[cnt*(myidx-1)+1:cnt*myidx]
     else
         _, data = get_msg(:scatter, pid, tag)
@@ -208,13 +208,13 @@ end
 
 function gather(x, pid::Int; tag=nothing, pids=procs())
     if myid() == pid
-        gathered_data = Array{Any}(length(pids))
-        myidx = findfirst(sort(pids), pid)
+        gathered_data = Array{Any}(undef, length(pids))
+        myidx = findfirst(isequal(pid), sort(pids))
         gathered_data[myidx] = x
         n = length(pids) - 1
         while n > 0
             from, data_x = get_msg(:gather, false, tag)
-            fromidx = findfirst(sort(pids), from)
+            fromidx = findfirst(isequal(from), sort(pids))
             gathered_data[fromidx] = data_x
             n=n-1
         end

--- a/src/spmd.jl
+++ b/src/spmd.jl
@@ -24,7 +24,7 @@ mutable struct SPMDContext
 
     function SPMDContext(id)
         ctxt = new(id, Channel(typemax(Int)), Dict{Any,Any}(), [], false)
-        finalizer(ctxt, finalize_ctxt)
+        finalizer(finalize_ctxt, ctxt)
         ctxt
     end
 end
@@ -256,7 +256,7 @@ end
 
 function Base.close(ctxt::SPMDContext)
     for p in ctxt.pids
-        Base.remote_do(delete_ctxt_id, p, ctxt.id)
+        remote_do(delete_ctxt_id, p, ctxt.id)
     end
     ctxt.release = false
 end

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -182,6 +182,7 @@ check_leaks()
 
     @testset "test map / reduce" begin
         D2 = map(x->1, D)
+        @test D2 isa DArray
         @test reduce(+, D2) == 100
         close(D2)
     end

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -118,7 +118,8 @@ check_leaks()
     end
 
     @testset "test invalid use of @DArray" begin
-        @test_throws ArgumentError eval(:((@DArray [1,2,3,4])))
+        #@test_throws ArgumentError eval(:((@DArray [1,2,3,4])))
+        @test_throws LoadError eval(:((@DArray [1,2,3,4])))
     end
 end
 

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -1,4 +1,4 @@
-using SpecialFunctions
+using Test, LinearAlgebra, SpecialFunctions
 
 @testset "test distribute and other constructors" begin
     A = rand(1:100, (100,100))
@@ -197,22 +197,23 @@ check_leaks()
 @testset "test scale" begin
     A = randn(100,100)
     DA = distribute(A)
-    @test scale!(DA, 2) == scale!(A, 2)
+    @test rmul!(DA, 2) == rmul!(A, 2)
     close(DA)
 end
 
 check_leaks()
 
-@testset "test scale!(b, A)" begin
+@testset "test rmul!(Diagonal, A)" begin
     A = randn(100, 100)
     b = randn(100)
+    D = Diagonal(b)
     DA = distribute(A)
-    @test scale!(b, A) == scale!(b, DA)
+    @test lmul!(D, A) == lmul!(D, DA)
     close(DA)
     A = randn(100, 100)
     b = randn(100)
     DA = distribute(A)
-    @test scale!(A, b) == scale!(DA, b)
+    @test rmul!(A, D) == rmul!(DA, D)
     close(DA)
 end
 
@@ -644,12 +645,12 @@ check_leaks()
     end
     @testset "test transpose real" begin
         A = drand(Float64, 200, 100)
-        @test A.' == Array(A).'
+        @test transpose(A) == transpose(Array(A))
         close(A)
     end
     @testset "test ctranspose complex" begin
         A = drand(Complex128, 100, 200)
-        @test A.' == Array(A).'
+        @test transpose(A) == transpose(Array(A))
         close(A)
     end
 
@@ -827,8 +828,8 @@ check_leaks()
     for (x, y) in ((drandn(20), drandn(20)),
                    (drandn(20, 2), drandn(20, 2)))
 
-        @test Array(LinAlg.axpy!(2.0, x, copy(y))) ≈ LinAlg.axpy!(2.0, Array(x), Array(y))
-        @test_throws DimensionMismatch LinAlg.axpy!(2.0, x, zeros(length(x) + 1))
+        @test Array(axpy!(2.0, x, copy(y))) ≈ axpy!(2.0, Array(x), Array(y))
+        @test_throws DimensionMismatch axpy!(2.0, x, zeros(length(x) + 1))
         close(x)
         close(y)
     end
@@ -867,11 +868,11 @@ end
     b = convert(Array, B)
 
     AB = A * B
-    AtB = A.' * B
+    AtB = transpose(A) * B
     AcB = A' * B
 
     ab = a * b
-    atb = a.' * b
+    atb = transpose(a) * b
     acb = a' * b
 
     @test AB ≈ ab

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -1,4 +1,9 @@
+<<<<<<< HEAD
 using Test, LinearAlgebra, SpecialFunctions
+=======
+using SpecialFunctions
+using LinearAlgebra
+>>>>>>> scale! -> [lr]mul!
 
 @testset "test distribute and other constructors" begin
     A = rand(1:100, (100,100))
@@ -196,7 +201,7 @@ end
 
 check_leaks()
 
-@testset "test scale" begin
+@testset "test rmul" begin
     A = randn(100,100)
     DA = distribute(A)
     @test rmul!(DA, 2) == rmul!(A, 2)
@@ -205,17 +210,29 @@ end
 
 check_leaks()
 
+<<<<<<< HEAD
 @testset "test rmul!(Diagonal, A)" begin
+=======
+@testset "test [lr]mul!(b, A)" begin
+>>>>>>> scale! -> [lr]mul!
     A = randn(100, 100)
     b = randn(100)
     D = Diagonal(b)
     DA = distribute(A)
+<<<<<<< HEAD
     @test lmul!(D, A) == lmul!(D, DA)
+=======
+    @test lmul!(Diagonal(b), A) == lmul!(Diagonal(b), DA)
+>>>>>>> scale! -> [lr]mul!
     close(DA)
     A = randn(100, 100)
     b = randn(100)
     DA = distribute(A)
+<<<<<<< HEAD
     @test rmul!(A, D) == rmul!(DA, D)
+=======
+    @test rmul!(A, Diagonal(b)) == rmul!(A, Diagonal(b))
+>>>>>>> scale! -> [lr]mul!
     close(DA)
 end
 

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -892,9 +892,10 @@ end
     d = DistributedArrays.drand(T, 10^i)
     @testset "sample = $sample" for sample in Any[true, false, (minimum(d),maximum(d)), rand(T, 10^i>512 ? 512 : 10^i)]
         d2 = DistributedArrays.sort(d; sample=sample)
-
+        a  = convert(Array, d)
+        a2 = convert(Array, d2)
         @test length(d) == length(d2)
-        @test sort(convert(Array, d)) == convert(Array, d2)
+        @test sort(a) == a2
     end
     d_closeall()  # close the temporaries created above
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
-using Test, Distributed
+using Test
+using Distributed
+using DistributedArrays
 
 # add at least 3 worker processes
 if nworkers() < 3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,10 @@ using Test
 using Distributed
 using DistributedArrays
 
+# Disable scalar indexing to avoid falling back on generic methods
+# for AbstractArray
+DistributedArrays.allowscalar(false)
+
 # add at least 3 worker processes
 if nworkers() < 3
     n = max(3, min(8, Sys.CPU_THREADS))
@@ -10,6 +14,7 @@ end
 @assert nprocs() > 3
 @assert nworkers() >= 3
 
+@everywhere using Distributed
 @everywhere using DistributedArrays
 @everywhere using DistributedArrays.SPMD
 @everywhere using Random
@@ -23,7 +28,7 @@ const OTHERIDS = filter(id-> id != MYID, procs())[rand(1:(nprocs()-1))]
 function check_leaks()
     if length(DistributedArrays.refs) > 0
         sleep(0.1)  # allow time for any cleanup to complete and test again
-        length(DistributedArrays.refs) > 0 && warn("Probable leak of ", length(DistributedArrays.refs), " darrays")
+        length(DistributedArrays.refs) > 0 && @warn("Probable leak of ", length(DistributedArrays.refs), " darrays")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,17 +1,16 @@
-using Base.Test
-
-using DistributedArrays
+using Test, Distributed
 
 # add at least 3 worker processes
 if nworkers() < 3
-    n = max(3, min(8, Sys.CPU_CORES))
+    n = max(3, min(8, Sys.CPU_THREADS))
     addprocs(n; exeflags=`--check-bounds=yes`)
 end
 @assert nprocs() > 3
 @assert nworkers() >= 3
 
-@everywhere importall DistributedArrays
-@everywhere importall DistributedArrays.SPMD
+@everywhere using DistributedArrays
+@everywhere using DistributedArrays.SPMD
+@everywhere using Random
 
 @everywhere srand(1234 + myid())
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ end
 @everywhere using DistributedArrays
 @everywhere using DistributedArrays.SPMD
 @everywhere using Random
+@everywhere using LinearAlgebra
 
 @everywhere srand(1234 + myid())
 

--- a/test/spmd.jl
+++ b/test/spmd.jl
@@ -105,7 +105,7 @@ spmd(spmd_test1)
 end
 
 # run foo_spmd on all workers, many of them, all concurrently using implictly different contexts.
-in_arrays = map(x->DArray(I->fill(myid(), (map(length,I)...)), (nworkers(), 2), workers(), [nworkers(),1]), 1:8)
+in_arrays = map(x->DArray(I->fill(myid(), (map(length,I)...,)), (nworkers(), 2), workers(), [nworkers(),1]), 1:8)
 out_arrays = map(x->ddata(), 1:8)
 
 @sync for i in 1:8
@@ -151,7 +151,7 @@ println("SPMD: Passed testing of spmd function run concurrently")
 end
 
 
-in_arrays = map(x->DArray(I->fill(myid(), (map(length,I)...)), (nworkers(), 2), workers(), [nworkers(),1]), 1:8)
+in_arrays = map(x->DArray(I->fill(myid(), (map(length,I)...,)), (nworkers(), 2), workers(), [nworkers(),1]), 1:8)
 out_arrays = map(x->ddata(), 1:8)
 contexts = map(x->context(workers()), 1:8)
 

--- a/test/spmd.jl
+++ b/test/spmd.jl
@@ -76,7 +76,7 @@ spmd(spmd_test1)
 # define the function everywhere
 @everywhere function foo_spmd(d_in, d_out, n)
     pids=sort(vec(procs(d_in)))
-    pididx = findfirst(pids, myid())
+    pididx = findfirst(isequal(myid()), pids)
     mylp = localpart(d_in)
     localsum = 0
 
@@ -122,7 +122,7 @@ println("SPMD: Passed testing of spmd function run concurrently")
 # define the function everywhere
 @everywhere function foo_spmd2(d_in, d_out, n)
     pids=sort(vec(procs(d_in)))
-    pididx = findfirst(pids, myid())
+    pididx = findfirst(isequal(myid()), pids)
     mylp = localpart(d_in)
 
     # see if we have a value in the local store.
@@ -170,7 +170,7 @@ end
 # verify localstores with appropriate context store values exist.
 @everywhere begin
     if myid() != 1
-        n = 0
+        local n = 0
         for (k,v) in DistributedArrays.SPMD.map_ctxts
             store = v.store
             localsum = store[:LOCALSUM]


### PR DESCRIPTION
This change makes DistributedArrays work on julia 0.7, but compatibility with 0.6 is lost. All tests pass without deprecation warnings.

There are many minor syntax/library changes, and the following major changes:

1. The `broadcast` implementation has been rewritten. The basic strategy is to rewrite the `Broadcasted` object into its equivalent for the localparts. This will probably only work if all involved arrays are distributed in a "compatible" way. More work is needed to make it fully general.
2. `localindexes` renamed to `localindices`, reflecting the current convention in Julia.
3. `deepcopy(::DArray)` added.
4. `importall Base` was removed.

Note that there seems to be an obscure [issue in Julia](https://github.com/JuliaLang/julia/issues/28083) which one currently has to work around by calling `using DistributedArrays` on the master process before calling `@everywhere using DistributedArrays`.

Calls to `reduce` and `mapreduce` with the `dims` keyword (which replace the `reducedim` and `mapreducedim` functions) are currently slow and I guess some part is falling back to methods for `AbstractArray`. There is related code in `src/darray.jl` which is still getting called, but I haven't managed to figure out the call path from the `Base` method.