### PR TITLE
Fix for Inconsistent Uneven Grid Distributions

### DIFF
--- a/src/darray.jl
+++ b/src/darray.jl
@@ -285,7 +285,7 @@ end
 # get array of start indices for dividing sz into nc chunks
 function defaultdist(sz::Int, nc::Int)
     if sz >= nc
-        return round.(Int, range(1, stop=sz+1, length=nc+1))
+        return ceil.(Int, range(1, stop=sz+1, length=nc+1))
     else
         return [[1:(sz+1);]; zeros(Int, nc-sz)]
     end

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -58,10 +58,11 @@ using SparseArrays: nnz
     end
     
     @testset "Consistent Uneven Distribution issue #166" begin
-        DA = drand((7,), procs()[1:3], 3)
+        DA = drand((7,), [MYID, OTHERIDS[1:2]])
         @test fetch(@spawnat MYID length(localpart(DA)) == 3)
-        @test fetch(@spawnat OTHERIDS length(localpart(DA)) == 2)
+        @test fetch(@spawnat OTHERIDS[1:2] length(localpart(DA)) == 2)
         close(DA)
+    end
 end
 
 check_leaks()

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -58,9 +58,9 @@ using SparseArrays: nnz
     end
     
     @testset "Consistent Uneven Distribution issue #166" begin
-        DA = drand((7,), [MYID, OTHERIDS[1:2]])
-        @test fetch(@spawnat MYID length(localpart(DA)) == 3)
-        @test fetch(@spawnat OTHERIDS[1:2] length(localpart(DA)) == 2)
+        DA = drand((7,), [1,2,3])
+        @test fetch(@spawnat 1 length(localpart(DA)) == 3)
+        @test fetch(@spawnat [2,3] length(localpart(DA)) == 2)
         close(DA)
     end
 end

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -58,9 +58,9 @@ using SparseArrays: nnz
     end
     
     @testset "Consistent Uneven Distribution issue #166" begin
-        DA = drand((7,), [1,2,3])
-        @test fetch(@spawnat 1 length(localpart(DA)) == 3)
-        @test fetch(@spawnat [2,3] length(localpart(DA)) == 2)
+        DA = drand((2+length(OTHERIDS),), [MYID, OTHERIDS])
+        @test fetch(@spawnat MYID length(localpart(DA)) == 2)
+        @test fetch(@spawnat OTHERIDS length(localpart(DA)) == 1)
         close(DA)
     end
 end

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -56,6 +56,12 @@ using SparseArrays: nnz
         @test DistributedArrays.empty_localpart(Float64,2,LowerTriangular{Float64,Matrix{Float64}}) isa
                 LowerTriangular
     end
+    
+    @testset "Consistent Uneven Distribution issue #166" begin
+        DA = drand((7,), procs()[1:3], 3)
+        @test fetch(@spawnat MYID length(localpart(DA)) == 3)
+        @test fetch(@spawnat OTHERIDS length(localpart(DA)) == 2)
+        close(DA)
 end
 
 check_leaks()


### PR DESCRIPTION
This closes #166 
Was an unexpectedly minor change.
If anyone more familiar with edge cases can test this I would appreciate it, but I think given the behavior of range and the previously inconsistent distribution before this shouldn't break anything.

Properly produces 3,2,2 distribution for 7 split three ways and 2,2,2,1 for 7 split four ways. 