### PR TITLE
Fixes Edge Cases with #167

### DIFF
--- a/src/darray.jl
+++ b/src/darray.jl
@@ -285,7 +285,17 @@ end
 # get array of start indices for dividing sz into nc chunks
 function defaultdist(sz::Int, nc::Int)
     if sz >= nc
-        return ceil.(Int, range(1, stop=sz+1, length=nc+1))
+        chunk_size = div(sz,nc)
+        remainder = rem(sz,nc)
+        grid = Array(1:chunk_size:sz+1)
+        for i = 1:(nc+1)
+            if i<= remainder
+                grid[i] += i-1
+            else
+                grid[i] += remainder
+            end
+        end
+        return grid
     else
         return [[1:(sz+1);]; zeros(Int, nc-sz)]
     end

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -62,7 +62,7 @@ using SparseArrays: nnz
         @test fetch(@spawnat MYID length(localpart(DA)) == 2)
         @test fetch(@spawnat OTHERIDS length(localpart(DA)) == 1)
         close(DA)
-        @test defaultdist(50,4) == [1,14,27,39,51]
+        @test DistributedArrays.defaultdist(50,4) == [1,14,27,39,51]
     end
     
     

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -62,7 +62,10 @@ using SparseArrays: nnz
         @test fetch(@spawnat MYID length(localpart(DA)) == 2)
         @test fetch(@spawnat OTHERIDS length(localpart(DA)) == 1)
         close(DA)
+        @test defaultdist(50,4) == [1,14,27,39,51]
     end
+    
+    
 end
 
 check_leaks()


### PR DESCRIPTION
The previous solution (#167 ) was incorrect when the range resulted in a whole number output.
For example a length 50 array being split over 4 was resulting in 13,12,13,12.

The new solution is less elegant, but doesn't rely on using range so has no issues with rounding being inconsistent.

I am unsure how to actually write a test for this as all the ways I can think to do so depend on me indexing OTHERIDS which seems to throw an exception.