### PR TITLE
Introduce makelocal

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -8,7 +8,7 @@ Base.map(f, d0::DArray, ds::AbstractArray...) = broadcast(f, d0, ds...)
 function Base.map!(f::F, dest::DArray, src::DArray{<:Any,<:Any,A}) where {F,A}
     asyncmap(procs(dest)) do p
         remotecall_fetch(p) do
-            map!(f, localpart(dest), A(view(src, localindices(dest)...)))
+            map!(f, localpart(dest), makelocal(src, localindices(dest)...))
             return nothing
         end
     end

--- a/test/darray.jl
+++ b/test/darray.jl
@@ -712,6 +712,25 @@ end
 
 check_leaks()
 
+@testset "makelocal" begin
+    A = randn(5*nprocs(), 5*nprocs())
+    dA = distribute(A, procs=procs())
+    for i in 1:size(dA, 2)
+        a = DistributedArrays.makelocal(dA, :, i)
+        @test all(Array(view(dA, :, i)) .== a)
+        @test all(      view( A, :, i) .== a)
+    end
+    for i in 1:size(dA, 1)
+        a = DistributedArrays.makelocal(dA, i, :)
+        @test all(Array(view(dA, i:i, :)) .== a)
+        @test all(      view( A, i:i, :) .== a)
+    end
+    a = DistributedArrays.makelocal(dA, 1:5, 1:5)
+    @test all(Array(view(dA, 1:5, 1:5)) .== a)
+    @test all(      view( A, 1:5, 1:5) .== a)
+    close(dA)
+end
+
 @testset "test convert from subdarray" begin
     a = drand(20, 20);
 


### PR DESCRIPTION
Optimise the makelocal pattern of creating a view and then copying
it locally. If the data is local this will return a view to the data
instead.