### PR TITLE
Include SparseArrays as a dep in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
@@ -15,8 +16,7 @@ julia = ">= 1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [targets]
-test = ["Test", "SparseArrays", "SpecialFunctions"]
+test = ["Test", "SpecialFunctions"]


### PR DESCRIPTION
Without this change, I was seeing the following warning:
```
┌ Warning: Package DistributedArrays does not have SparseArrays in its dependencies:
│ - If you have DistributedArrays checked out for development and have
│   added SparseArrays as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with DistributedArrays
└ Loading SparseArrays into DistributedArrays from project dependency, future warnings for DistributedArrays are suppressed.
```
I guess this is because `src/mapreduce.jl` does 'import SparseArrays: nnz'?