### PR TITLE
Fix for issue #223, type declaration in macro

### DIFF
--- a/src/darray.jl
+++ b/src/darray.jl
@@ -241,7 +241,10 @@ macro DArray(ex0::Expr)
         var = ex.args[d+1].args[1]
         ex.args[d+1] = :( $(esc(var)) = ($(ranges[d]))[I[$d]] )
     end
-    return :( DArray((I::Tuple{Vararg{UnitRange{Int}}})->($ex0),
+    
+    fdef=:(local _ff(I::Tuple{Vararg{UnitRange{Int}}}) = $ex0)
+            
+    return :( DArray($fdef,
                 tuple($(map(r->:(length($r)), ranges)...))) )
 end
 


### PR DESCRIPTION
This should fix #223, so maybe a a new version can be tagged waiting for an upstream fix if it is really a bug. I tried to preserve the type declaration, let's see if any of the tests break.