### PR TITLE
Make similar produce the same distribution when the size is the same

### DIFF
--- a/src/darray.jl
+++ b/src/darray.jl
@@ -251,9 +251,9 @@ DArray(init, d::DArray) = DArray(next_did(), init, size(d), procs(d), d.indices,
 sz_localpart_ref(ref, id) = size(fetch(ref))
 
 Base.similar(d::DArray, T::Type, dims::Dims) = DArray(I->Array{T}(undef, map(length,I)), dims, procs(d))
-Base.similar(d::DArray, T::Type) = similar(d, T, size(d))
+Base.similar(d::DArray, T::Type) = DArray(I->Array{T}(undef, map(length,I)), size(d), procs(d),size(d.indices))
 Base.similar(d::DArray{T}, dims::Dims) where {T} = similar(d, T, dims)
-Base.similar(d::DArray{T}) where {T} = similar(d, T, size(d))
+Base.similar(d::DArray{T}) where {T} = DArray(I->Array{T}(undef, map(length,I)), size(d), procs(d),size(d.indices))
 
 Base.size(d::DArray) = d.dims
 


### PR DESCRIPTION
Hello,

If the user has bothered to pass an explicit distribution, respect it in `similar` arrays.  This prevents behavior as below:
```
julia> dd=drand((10,10),workers(),[2,1]);

julia> ds=similar(dd);

julia> ds.indices
1x2 Array{Tuple{UnitRange{Int64},UnitRange{Int64}},2}:
 (1:10, 1:5)  (1:10, 6:10)

julia> dd.indices
2x1 Array{Tuple{UnitRange{Int64},UnitRange{Int64}},2}:
 (1:5, 1:10)
 (6:10, 1:10)
```
A smarter implementation that tries to make a judicious distribution depending on `Dims` gets complicated fast. This is the low hanging fruit.

Hope this helps!