### PR TITLE
fix `close` error due to race in `d_closeall`

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -44,7 +44,10 @@ function d_closeall()
     crefs = copy(refs)
     for id in crefs
         if id[1] ==  myid() # sanity check
-            haskey(registry, id) && close(d_from_weakref_or_d(id))
+            if haskey(registry, id)
+                d = d_from_weakref_or_d(id)
+                (d === nothing) || close(d)
+            end
             yield()
         end
     end


### PR DESCRIPTION
It seems possible that `DistributedArrays.d_closeall()` may encounter a condition where it finds a darray id in the `registry`, but the corresponding weakref value is `nothing` because the referenced darray got garbage collected. It has been enountered many times in CI and elsewhere, but is hard to replicate normally. Adding a check for the weakref value, before actually invoking `close` on it, to fix it.

fixes #246 