### PR TITLE
Use `loggamma` instead of deprecated `lgamma` in tests

### DIFF
--- a/test/darray.jl
+++ b/test/darray.jl
@@ -780,7 +780,7 @@ check_leaks()
               erfcx, erfi, erfinv, exp, exp10, exp2,
               expm1, exponent, float, floor, gamma, imag,
               invdigamma, isfinite, isinf, isnan,
-              lgamma, log, log10, log1p, log2, rad2deg, real,
+              loggamma, log, log10, log1p, log2, rad2deg, real,
               sec, secd, sech, sign, sin, sinc, sind,
               sinh, sinpi, sqrt, tan, tand, tanh, trigamma)
         @test f.(a) == f.(b)


### PR DESCRIPTION
Currently, the deprecated function `SpecialFunctions.lgamma` is used in the tests. This PR changes the test to `SpecialFunctions.loggamma`.