### PR TITLE
Fix typo in CompatHelper config

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Run CompatHelper"
         run: |
           import CompatHelper
-          CompatHelper.main(; dirs = ["", "docs"])
+          CompatHelper.main(; subdirs = ["", "docs"])
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The keyword argument is called `subdirs`, not `dirs`.