### PR TITLE
Make DistributedArrays thread-safe

### DIFF
--- a/test/darray.jl
+++ b/test/darray.jl
@@ -1052,10 +1052,10 @@ d_closeall()
 
 @testset "test for any leaks" begin
     sleep(1.0)     # allow time for any cleanup to complete
-    allrefszero = Bool[remotecall_fetch(()->length(DistributedArrays.refs) == 0, p) for p in procs()]
+    allrefszero = Bool[remotecall_fetch(()-> @lock(DistributedArrays.REFS.lock, isempty(DistributedArrays.REFS.data)), p) for p in procs()]
     @test all(allrefszero)
 
-    allregistrieszero = Bool[remotecall_fetch(()->length(DistributedArrays.registry) == 0, p) for p in procs()]
+    allregistrieszero = Bool[remotecall_fetch(()-> @lock(DistributedArrays.REGISTRY.lock, isempty(DistributedArrays.REGISTRY.data)), p) for p in procs()]
     @test all(allregistrieszero)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,9 +26,13 @@ const MYID = myid()
 const OTHERIDS = filter(id-> id != MYID, procs())[rand(1:(nprocs()-1))]
 
 function check_leaks()
-    if length(DistributedArrays.refs) > 0
+    nrefs = @lock DistributedArrays.REFS.lock length(DistributedArrays.REFS.data)
+    if !iszero(nrefs)
         sleep(0.1)  # allow time for any cleanup to complete and test again
-        length(DistributedArrays.refs) > 0 && @warn("Probable leak of ", length(DistributedArrays.refs), " darrays")
+        nrefs = @lock DistributedArrays.REFS.lock length(DistributedArrays.REFS.data)
+        if !iszero(nrefs)
+            @warn("Probable leak of ", nrefs, " darrays")
+        end
     end
 end
 


### PR DESCRIPTION
By putting locks around the global dictionaries in `DistributedArrays` and `DistributedArrays.SPMD`, and using an `Atomic` for the ID generation.

While it works, I think conceptually it would be cleaner to store references of remote parts locally, associated with each array, and make use of the reference tracking and garbage collection behaviour of `RemoteChannel`s: https://docs.julialang.org/en/v1/manual/distributed-computing/#Remote-References-and-Distributed-Garbage-Collection As advised in the docs, to reduce memory on the workers in the finalizer of each array we could call `finalize` on the `RemoteChannel`.